### PR TITLE
Accept some settings as environment variables.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ debug = ['serde_json']
 [dependencies]
 anyhow = "1.0"
 bincode = "1.3.1"
-clap = { version = "3.0", default_features = false, features = ["std", "derive"] }
+clap = { version = "3.0", default_features = false, features = ["std", "derive", "env"] }
 humantime = "2.1.0"
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -171,9 +171,12 @@ partition it will be significantly faster than caching to a spinning disk.
 
 ### Environment Variables
 
-Some settings can be passed via those environment variables:
+Some settings can be passed via the following environment variables:
 
-`BKT_SCOPE`, `BKT_CACHE_DIR`, `BKT_TTL`, and `BKT_STALE`.
+- `BKT_SCOPE` for [`--scope`](#setting-a-cache-scope)
+- `BKT_CACHE_DIR` for [`--cache-dir`](#changing-the-cache-directory)
+- `BKT_TTL` for [`--ttl`](#cache-lifespan)
+- `BKT_STALE` for [`--stale`](#cache-lifespan)
 
 
 ## Security and Privacy

--- a/README.md
+++ b/README.md
@@ -169,6 +169,13 @@ Note that the choice of directory can affect `bkt`'s performance: if the cache
 is stored under a [`tmpfs`](https://en.wikipedia.org/wiki/Tmpfs) or solid-state
 partition it will be significantly faster than caching to a spinning disk.
 
+### Environment Variables
+
+Some settings can be passed via those environment variables:
+
+`BKT_SCOPE`, `BKT_CACHE_DIR`, `BKT_TTL`, and `BKT_STALE`.
+
+
 ## Security and Privacy
 
 The default cache directory is potentially world-readable. On Unix the cache

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ frequently than the `--ttl` would suggest, which in turn can create unexpected
 load. If the backing command is failing due to an outage or bug (such as an
 overloaded website) triggering additional calls can exacerbate the issue and
 effectively DDoS the hampered system. It is generally safer *not* to set this
-flag and instead make the client robust to occasional failures. 
+flag and instead make the client robust to occasional failures.
 
 <a name="cache_dir"></a>
 ### Changing the Cache Directory

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ partition it will be significantly faster than caching to a spinning disk.
 Some settings can be passed via the following environment variables:
 
 - `BKT_SCOPE` for [`--scope`](#setting-a-cache-scope)
-- `BKT_CACHE_DIR` for [`--cache-dir`](#changing-the-cache-directory)
+- `BKT_TMPDIR` for [`--cache-dir`](#changing-the-cache-directory)
 - `BKT_TTL` for [`--ttl`](#cache-lifespan)
 - `BKT_STALE` for [`--stale`](#cache-lifespan)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,7 +149,7 @@ struct Cli {
     /// defaults to the system's temp directory.
     /// Setting this to a directory backed by RAM or an SSD, such as a tmpfs partition,
     /// will significantly reduce caching overhead.
-    #[clap(long, env = "BKT_CACHE_DIR")]
+    #[clap(long, env = "BKT_TMPDIR")]
     cache_dir: Option<PathBuf>,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,11 +109,11 @@ struct Cli {
     command: Vec<OsString>,
 
     /// Duration the cached result will be valid for
-    #[clap(long, default_value = "60s", visible_alias = "time-to-live")]
+    #[clap(long, default_value = "60s", visible_alias = "time-to-live", env = "BKT_TTL")]
     ttl: humantime::Duration,
 
     /// Duration after which the result will be asynchronously refreshed
-    #[clap(long, conflicts_with = "warm")]
+    #[clap(long, conflicts_with = "warm", env = "BKT_STALE")]
     stale: Option<humantime::Duration>,
 
     /// Asynchronously execute and cache the given command, even if it's already cached
@@ -142,14 +142,14 @@ struct Cli {
 
     /// If set, all cached data will be scoped to this value,
     /// preventing collisions with commands cached with different scopes
-    #[clap(long)]
+    #[clap(long, env = "BKT_SCOPE")]
     scope: Option<String>,
 
     /// The directory under which to persist cached invocations;
     /// defaults to the system's temp directory.
     /// Setting this to a directory backed by RAM or an SSD, such as a tmpfs partition,
     /// will significantly reduce caching overhead.
-    #[clap(long)]
+    #[clap(long, env = "BKT_CACHE_DIR")]
     cache_dir: Option<PathBuf>,
 }
 


### PR DESCRIPTION
Beware it's my first bits in rust, I don't know what I'm doing.

Context: I'm using bkt many times in the same file and would like for all caches to land in the same cache directory and be reusable for way more than 30s but I don't want to add `--cache-dir` and `--ttl` at each line.

More context: I'm [writing slides](https://github.com/JulienPalard/formations/blob/e64ffb6cd9ff72bc300284720807b3ad02e057e8/python-perfs/perfs.md?plain=1#L66) in Markdown, but don't want to copy/paste commands output in my slides (I'll have too much), so I'm using a [simple sed trick](https://github.com/JulienPalard/formations/blob/e64ffb6cd9ff72bc300284720807b3ad02e057e8/python-perfs/Makefile#L17) to execute the commands from the Markdown file, but now it's too slow to render the slides so I want to use bkt to cache commands output, but now it's too verbose so I'd like to configure bkt from my Makefile with some environment variables instead of from the Markdown files...