### PR TITLE
CD: add linux musl builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,9 +39,11 @@ jobs:
         arch:
           - { target: arm-unknown-linux-gnueabihf , os: ubuntu-20.04, use-cross: true                }
           - { target: i686-unknown-linux-gnu      , os: ubuntu-20.04, use-cross: true                }
+          - { target: i686-unknown-linux-musl     , os: ubuntu-20.04, use-cross: true                }
           - { target: x86_64-apple-darwin         , os: macos-10.15                                  }
           - { target: x86_64-pc-windows-msvc      , os: windows-2019                  , suffix: .exe }
           - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04                                 }
+          - { target: x86_64-unknown-linux-musl   , os: ubuntu-20.04, use-cross: true                }
     steps:
       - uses: actions/checkout@v2
       - name: Extract crate information


### PR DESCRIPTION
A statically linked version of `bkt` is useful as glibc (or new enough version of glibc) may not be available. 