### PR TITLE
gate the stable_hash test to only run on little endinan machines

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -867,6 +867,7 @@ mod cache_tests {
 
     // Sanity-checking that cache_key's behavior is stable over time. This test may need to be
     // updated when changing Rust versions / editions.
+    #[cfg(target_endian = "little")]
     #[test]
     fn stable_hash() {
         assert_eq!(100.cache_key(), "7D208C81E8236995");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -867,6 +867,7 @@ mod cache_tests {
 
     // Sanity-checking that cache_key's behavior is stable over time. This test may need to be
     // updated when changing Rust versions / editions.
+    // Disabled on hardware that generates other hashes, see #39
     #[cfg(target_endian = "little")]
     #[test]
     fn stable_hash() {


### PR DESCRIPTION
fixes #39 (I hope, lacking a test machine to verify on)