### PR TITLE
ci: Attempt to add aarch64 osx build to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,6 +44,7 @@ jobs:
           - { target: i686-unknown-linux-gnu      , os: ubuntu-20.04 , use-cross: true                }
           - { target: i686-unknown-linux-musl     , os: ubuntu-20.04 , use-cross: true                }
           - { target: x86_64-apple-darwin         , os: macos-12                                      }
+          - { target: aarch64-apple-darwin        , os: macos-14                                      }
           - { target: x86_64-pc-windows-msvc      , os: windows-2019                   , suffix: .exe }
           - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04                                  }
           - { target: x86_64-unknown-linux-musl   , os: ubuntu-20.04 , use-cross: true                }


### PR DESCRIPTION
Add  target `aarch64-apple-darwin` as done in https://github.com/sharkdp/fd/pull/1552

Fix: #17
:crossed_fingers: 